### PR TITLE
Run checks across more OS and Go versions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -7,13 +7,22 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go_version:
+          - "1.22"
+          - "1.23"
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version: ${{ matrix.go_version }}
       - name: test
         run: make report-coverage
       - name: check-coverage

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -17,6 +17,8 @@ jobs:
       - name: test
         run: make report-coverage
       - name: check-coverage
+        # only bother checking coverage on Linux
+        if: matrix.os == 'ubuntu-latest'
         run: make check-coverage
 
   lint:

--- a/cmd/main_interrupt_test.go
+++ b/cmd/main_interrupt_test.go
@@ -28,7 +28,7 @@ func TestApp_ExitsOnSigint(t *testing.T) {
 		time.Second,
 		10*time.Millisecond,
 	)
-	args := append(progArgs, "--from-sha", "HEAD", "--to-sha", "HEAD")
+	args := append(progArgs, "--from-ref", "HEAD", "--to-ref", "HEAD")
 
 	app := buildTestApp(io.Discard)
 	exit, err := runApp(interruptedCtx, app, args)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -184,6 +184,9 @@ func TestRelativeRepoAndModDirs(t *testing.T) {
 	require.NoError(t, err)
 	worktreePath, err := filepath.Rel(cwd, absWorktreePath)
 	require.NoError(t, err)
+	// the relative path might be a symlink (seen on GitHub action MacOS runner)
+	worktreePath, err = filepath.EvalSymlinks(worktreePath)
+	require.NoError(t, err)
 	modDir := filepath.Join(worktreePath, modPath)
 
 	prePatchHead, postPatchHead := commitPatches(t, worktreePath, patchName)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -25,6 +26,10 @@ var (
 	// mutex to avoid concurrent `git worktree` commands.
 	worktreeMutex sync.Mutex
 )
+
+func isWindows() bool {
+	return runtime.GOOS == "windows"
+}
 
 // the name of the test module.
 const testModuleName = "example.com/test-repo"
@@ -183,6 +188,9 @@ func TestRelativeRepoAndModDirs(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	worktreePath, err := filepath.Rel(cwd, absWorktreePath)
+	if err != nil && isWindows() {
+		t.Skip("skipping relative path test on windows")
+	}
 	require.NoError(t, err)
 	// the relative path might be a symlink (seen on GitHub action MacOS runner)
 	worktreePath, err = filepath.EvalSymlinks(worktreePath)
@@ -258,6 +266,9 @@ func commitPatches(t *testing.T, repoDir string, patchNames ...string) (string, 
 }
 
 func TestErrorsWhenFailsToReadPackages(t *testing.T) {
+	if isWindows() {
+		t.Skip("Not running on windows: uses chmod with unix permissions")
+	}
 	t.Parallel()
 	// create directory we don't have permission to search
 	modDir := filepath.Join(t.TempDir(), "moddir")
@@ -303,6 +314,9 @@ func TestErrorsWhenFailstoListingChangedFiles(t *testing.T) {
 func TestErrorsWhenFailsToReadingGoMod(t *testing.T) {
 	t.Parallel()
 	worktreeName := "remove-go-mod"
+	// the error uses the path given to us from `git diff`, and that uses `/`
+	// as the path separator, even on windows
+	reportedModPath := strings.Join(strings.Split(modPath, string(filepath.Separator)), "/")
 
 	err := runWithPatches(
 		t,
@@ -311,12 +325,16 @@ func TestErrorsWhenFailsToReadingGoMod(t *testing.T) {
 		io.Discard,
 	)
 
-	require.ErrorContains(t, err, "reading "+filepath.Join(modPath, "go.mod"))
+	require.ErrorContains(t, err, "reading "+reportedModPath+"/go.mod")
 }
 
 func TestErrorsWhenFailingToParseGoMod(t *testing.T) {
 	t.Parallel()
 	worktreePath := setupWorktree(t, "break-go-mod")
+	// the error uses the path given to us from `git diff`, and that uses `/`
+	// as the path separator, even on windows
+	reportedModPath := strings.Join(strings.Split(modPath, string(filepath.Separator)), "/")
+
 	// break `go.mod`...
 	_, headSha := commitPatches(t, worktreePath, "break-go-mod.patch")
 
@@ -326,7 +344,7 @@ func TestErrorsWhenFailingToParseGoMod(t *testing.T) {
 	require.ErrorContains(
 		t,
 		err,
-		"parsing mod file "+filepath.Join(modPath, "go.mod")+" at "+headSha,
+		"parsing mod file "+reportedModPath+"/go.mod"+" at "+headSha,
 	)
 }
 

--- a/cmd/testdata/repo/.gitattributes
+++ b/cmd/testdata/repo/.gitattributes
@@ -1,0 +1,3 @@
+# try and stop git running on Windows from converting line endings
+# in patches, since that renders them invalid
+patches/*.patch eol=lf


### PR DESCRIPTION
- Fix bad args in interrupt test

- Handle `TempDir` being symlinked

    For the specific test where we work with relative paths. It was seen
    while testing on MacOS runner that `git` would produce a path from `git
    diff` like:

        /var/folders/0w/4z5l9vds32nbkz7l22n8j6s80000gn/T/TestRelativeRepoAndModDirs1774773843/001/changed-test-relative-paths/cmd/testdata/repo/main.go

    But then `go list` would show:

        /private/var/folders/0w/4z5l9vds32nbkz7l22n8j6s80000gn/T/TestRelativeRepoAndModDirs1774773843/001/changed-test-relative-paths/cmd/testdata/repo/main.go

    I think `/var/folders` was symlinked to `/private/var/folders`, so make
    sure we resolve such links before invoking `git` for that test.

- Blindly attempt to fix Windows patch failing

    I don't have a Windows box to try this out on, but I was seeing errors
    like:

        running command: `git -C C:\Users\RUNNER~1\AppData\Local\Temp\TestWithSingleCommitchange-in-top-level-package.patch3855965763\001\patch-test-change-in-top-level-package.patch apply --index D:\a\go-changed-pkgs\go-changed-pkgs\cmd\testdata\repo\patches\change-in-top-level-package.patch`: exit status 128
        stderr: error: corrupt patch at line 8

    I've previously had experiences where testing on Windows breaks because
    a clean `git` install wants to normalize line endings, so address that
    issue by telling `git` to not do that.

- Fix some test failures on windows

    * `TestRelativeRepoAndModDirs` setting up relative paths might fail in
      windows like:

            Rel: can't make C:\Users\RUNNER~1\AppData\Local\Temp\TestRelativeRepoAndModDirs1928585117\001\changed-test-relative-paths relative to D:\a\go-changed-pkgs\go-changed-pkgs\cmd

    * `TestErrorsWhenFailsToReadPackages` relies on `chmod` unix like
      behaviour where the executable bit on a directory means search ability
      of that directory. In windows this bit does nothing, so skip the test

    * `TestErrorsWhenFailingToParseGoMod`,
      `TestErrorsWhenFailsToReadingGoMod` apparently Git lists files with
      `/` as the path separator (and not `\`) on Windows, and apparently
      this works just fine (I couldn't find from docs from Git explaining
      how/why this is done) but given all the other tests are passing I
      assume it's fine to just fix the test and we don't need to do any
      extra handling in the actual application. This fixes errors
      like:

        --- FAIL: TestErrorsWhenFailingToParseGoMod (2.69s)
            main_test.go:336:
                        Error Trace:	D:/a/go-changed-pkgs/go-changed-pkgs/cmd/main_test.go:336
                        Error:      	Error "getting changed packages: parsing mod file cmd/testdata/repo/go.mod at 52c050cadb125c642c7786e45dba2887d6e17ef2: cmd/testdata/repo/go.mod:1: unknown directive: THIS" does not contain "parsing mod file cmd\\testdata\\repo/go.mod at 52c050cadb125c642c7786e45dba2887d6e17ef2"
                        Test:       	TestErrorsWhenFailingToParseGoMod
        --- FAIL: TestErrorsWhenFailsToReadingGoMod (5.22s)
            main_test.go:324:
                        Error Trace:	D:/a/go-changed-pkgs/go-changed-pkgs/cmd/main_test.go:324
                        Error:      	Error "getting changed packages: reading cmd/testdata/repo/go.mod at cde94c447ef4192c4ce5fd5eb8bdad3e771cf352: running command: `git -C C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\TestErrorsWhenFailsToReadingGoMod3927317333\\001\\remove-go-mod show cde94c447ef4192c4ce5fd5eb8bdad3e771cf352:cmd/testdata/repo/go.mod`: exit status 128\nstderr: fatal: path 'cmd/testdata/repo/go.mod' does not exist in 'cde94c447ef4192c4ce5fd5eb8bdad3e771cf352'\n" does not contain "reading cmd\\testdata\\repo/go.mod"
                        Test:       	TestErrorsWhenFailsToReadingGoMod
        FAIL

- Only check coverage on Linux

- Run checks across more OS and Go versions