### PR TITLE
Add handling for `replace` directives in `go.mod`

### DIFF
--- a/cmd/testdata/repo/go.mod
+++ b/cmd/testdata/repo/go.mod
@@ -4,6 +4,9 @@ go 1.21.0
 
 require (
 	golang.org/x/mod v0.13.0
+	golang.org/x/net v0.2.0
 	golang.org/x/sys v0.14.0
 	golang.org/x/time v0.4.0
 )
+
+replace golang.org/x/net => github.com/golang/net v0.1.0

--- a/cmd/testdata/repo/go.sum
+++ b/cmd/testdata/repo/go.sum
@@ -1,3 +1,5 @@
+github.com/golang/net v0.1.0 h1:OdUL2NijOYO92eC8Gg0QkD2xLc6udJYEL8zfSo50rFY=
+github.com/golang/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/mod v0.13.0 h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=
 golang.org/x/mod v0.13.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=

--- a/cmd/testdata/repo/main.go
+++ b/cmd/testdata/repo/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	_ "golang.org/x/mod/modfile"
+	_ "golang.org/x/net/http2/hpack"
 
 	_ "example.com/test-repo/internal/consumer"
 )

--- a/cmd/testdata/repo/patches/add-replace.patch
+++ b/cmd/testdata/repo/patches/add-replace.patch
@@ -1,27 +1,24 @@
 diff --git a/cmd/testdata/repo/go.mod b/cmd/testdata/repo/go.mod
-index 6a00067..67d65f8 100644
+index 6a00067..3c9619d 100644
 --- a/cmd/testdata/repo/go.mod
 +++ b/cmd/testdata/repo/go.mod
-@@ -3,7 +3,7 @@ module example.com/test-repo
- go 1.21.0
+@@ -10,3 +10,5 @@ require (
+ )
  
- require (
--	golang.org/x/mod v0.13.0
-+	golang.org/x/mod v0.14.0
- 	golang.org/x/net v0.2.0
- 	golang.org/x/sys v0.14.0
- 	golang.org/x/time v0.4.0
+ replace golang.org/x/net => github.com/golang/net v0.1.0
++
++replace golang.org/x/mod => github.com/golang/mod v0.13.0
 diff --git a/cmd/testdata/repo/go.sum b/cmd/testdata/repo/go.sum
-index 66b216a..f6c596b 100644
+index 66b216a..9cb1c5d 100644
 --- a/cmd/testdata/repo/go.sum
 +++ b/cmd/testdata/repo/go.sum
 @@ -1,7 +1,7 @@
++github.com/golang/mod v0.13.0 h1:O24E959hoANN5pUW/JxvgNstO7h4tjx2fKWej4r1eT8=
++github.com/golang/mod v0.13.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
  github.com/golang/net v0.1.0 h1:OdUL2NijOYO92eC8Gg0QkD2xLc6udJYEL8zfSo50rFY=
  github.com/golang/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 -golang.org/x/mod v0.13.0 h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=
 -golang.org/x/mod v0.13.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
-+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
  golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
  golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
  golang.org/x/time v0.4.0 h1:Z81tqI5ddIoXDPvVQ7/7CC9TnLM7ubaFG2qXYd5BbYY=

--- a/cmd/testdata/repo/patches/config.yaml
+++ b/cmd/testdata/repo/patches/config.yaml
@@ -33,3 +33,10 @@ upgrade-second-level-dependency.patch:
 
 # change in files not related to any Go package
 change-in-unrelated-file.patch: []
+
+upgrade-replace-dependency.patch:
+  - ""
+add-replace.patch:
+  - ""
+remove-replace.patch:
+  - ""

--- a/cmd/testdata/repo/patches/remove-go-mod.patch
+++ b/cmd/testdata/repo/patches/remove-go-mod.patch
@@ -1,15 +1,18 @@
-diff --git a/cmd/testdata/repo/go.mod b/internal/changed/testdata/repo/go.mod
+diff --git a/cmd/testdata/repo/go.mod b/cmd/testdata/repo/go.mod
 deleted file mode 100644
-index 75a5ef2..0000000
+index 6a00067..0000000
 --- a/cmd/testdata/repo/go.mod
 +++ /dev/null
-@@ -1,9 +0,0 @@
+@@ -1,12 +0,0 @@
 -module example.com/test-repo
 -
 -go 1.21.0
 -
 -require (
 -	golang.org/x/mod v0.13.0
+-	golang.org/x/net v0.2.0
 -	golang.org/x/sys v0.14.0
 -	golang.org/x/time v0.4.0
 -)
+-
+-replace golang.org/x/net => github.com/golang/net v0.1.0

--- a/cmd/testdata/repo/patches/remove-replace.patch
+++ b/cmd/testdata/repo/patches/remove-replace.patch
@@ -1,0 +1,24 @@
+diff --git a/cmd/testdata/repo/go.mod b/cmd/testdata/repo/go.mod
+index 37c1e00..7a1af3e 100644
+--- a/cmd/testdata/repo/go.mod
++++ b/cmd/testdata/repo/go.mod
+@@ -8,5 +8,3 @@ require (
+ 	golang.org/x/sys v0.14.0
+ 	golang.org/x/time v0.4.0
+ )
+-
+-replace golang.org/x/net => github.com/golang/net v0.1.0
+diff --git a/cmd/testdata/repo/go.sum b/cmd/testdata/repo/go.sum
+index 66b216a..cfc8883 100644
+--- a/cmd/testdata/repo/go.sum
++++ b/cmd/testdata/repo/go.sum
+@@ -1,7 +1,7 @@
+-github.com/golang/net v0.1.0 h1:OdUL2NijOYO92eC8Gg0QkD2xLc6udJYEL8zfSo50rFY=
+-github.com/golang/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
+ golang.org/x/mod v0.13.0 h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=
+ golang.org/x/mod v0.13.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
++golang.org/x/net v0.2.0 h1:sZfSu1wtKLGlWI4ZZayP0ck9Y73K1ynO6gqzTdBVdPU=
++golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
+ golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+ golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/time v0.4.0 h1:Z81tqI5ddIoXDPvVQ7/7CC9TnLM7ubaFG2qXYd5BbYY=

--- a/cmd/testdata/repo/patches/syntax-error-in-package.patch
+++ b/cmd/testdata/repo/patches/syntax-error-in-package.patch
@@ -1,12 +1,12 @@
-diff --git a/cmd/testdata/repo/main.go b/internal/changed/testdata/repo/main.go
-index 353aede..8409e17 100644
+diff --git a/cmd/testdata/repo/main.go b/cmd/testdata/repo/main.go
+index c00d90a..89de200 100644
 --- a/cmd/testdata/repo/main.go
 +++ b/cmd/testdata/repo/main.go
-@@ -2,6 +2,7 @@
-
+@@ -3,6 +3,7 @@
  import (
  	_ "golang.org/x/mod/modfile"
+ 	_ "golang.org/x/net/http2/hpack"
 +	SYNTAX ERROR IN MAIN PACKAGE!
-
+ 
  	_ "example.com/test-repo/internal/consumer"
  )

--- a/cmd/testdata/repo/patches/upgrade-first-level-dependency.patch
+++ b/cmd/testdata/repo/patches/upgrade-first-level-dependency.patch
@@ -1,20 +1,22 @@
-diff --git a/cmd/testdata/repo/go.mod b/internal/changed/testdata/repo/go.mod
-index 75a5ef2..743302f 100644
+diff --git a/cmd/testdata/repo/go.mod b/cmd/testdata/repo/go.mod
+index 6a00067..c26c1b5 100644
 --- a/cmd/testdata/repo/go.mod
 +++ b/cmd/testdata/repo/go.mod
-@@ -4,6 +4,6 @@ go 1.21.0
-
+@@ -5,7 +5,7 @@ go 1.21.0
  require (
  	golang.org/x/mod v0.13.0
+ 	golang.org/x/net v0.2.0
 -	golang.org/x/sys v0.14.0
 +	golang.org/x/sys v0.15.0
  	golang.org/x/time v0.4.0
  )
-diff --git a/cmd/testdata/repo/go.sum b/internal/changed/testdata/repo/go.sum
-index e1f65f9..537901d 100644
+ 
+diff --git a/cmd/testdata/repo/go.sum b/cmd/testdata/repo/go.sum
+index 66b216a..9bd7316 100644
 --- a/cmd/testdata/repo/go.sum
 +++ b/cmd/testdata/repo/go.sum
-@@ -1,6 +1,6 @@
+@@ -2,7 +2,7 @@ github.com/golang/net v0.1.0 h1:OdUL2NijOYO92eC8Gg0QkD2xLc6udJYEL8zfSo50rFY=
+ github.com/golang/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
  golang.org/x/mod v0.13.0 h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=
  golang.org/x/mod v0.13.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 -golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=

--- a/cmd/testdata/repo/patches/upgrade-replace-dependency.patch
+++ b/cmd/testdata/repo/patches/upgrade-replace-dependency.patch
@@ -1,0 +1,22 @@
+diff --git a/cmd/testdata/repo/go.mod b/cmd/testdata/repo/go.mod
+index 6a00067..1e7158a 100644
+--- a/cmd/testdata/repo/go.mod
++++ b/cmd/testdata/repo/go.mod
+@@ -9,4 +9,4 @@ require (
+ 	golang.org/x/time v0.4.0
+ )
+ 
+-replace golang.org/x/net => github.com/golang/net v0.1.0
++replace golang.org/x/net => github.com/golang/net v0.12.0
+diff --git a/cmd/testdata/repo/go.sum b/cmd/testdata/repo/go.sum
+index 66b216a..be256d4 100644
+--- a/cmd/testdata/repo/go.sum
++++ b/cmd/testdata/repo/go.sum
+@@ -1,5 +1,5 @@
+-github.com/golang/net v0.1.0 h1:OdUL2NijOYO92eC8Gg0QkD2xLc6udJYEL8zfSo50rFY=
+-github.com/golang/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
++github.com/golang/net v0.12.0 h1:I/8qo6xYSv8vGnNq5uO32idhfmPwuBor+Ifmv0u6gUs=
++github.com/golang/net v0.12.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
+ golang.org/x/mod v0.13.0 h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=
+ golang.org/x/mod v0.13.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+ golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=

--- a/cmd/testdata/repo/patches/upgrade-second-level-dependency.patch
+++ b/cmd/testdata/repo/patches/upgrade-second-level-dependency.patch
@@ -1,19 +1,21 @@
-diff --git a/cmd/testdata/repo/go.mod b/internal/changed/testdata/repo/go.mod
-index 75a5ef2..f0b1710 100644
+diff --git a/cmd/testdata/repo/go.mod b/cmd/testdata/repo/go.mod
+index 6a00067..2314ff3 100644
 --- a/cmd/testdata/repo/go.mod
 +++ b/cmd/testdata/repo/go.mod
-@@ -5,5 +5,5 @@ go 1.21.0
- require (
+@@ -6,7 +6,7 @@ require (
  	golang.org/x/mod v0.13.0
+ 	golang.org/x/net v0.2.0
  	golang.org/x/sys v0.14.0
 -	golang.org/x/time v0.4.0
 +	golang.org/x/time v0.5.0
  )
-diff --git a/cmd/testdata/repo/go.sum b/internal/changed/testdata/repo/go.sum
-index e1f65f9..ce80821 100644
+ 
+ replace golang.org/x/net => github.com/golang/net v0.1.0
+diff --git a/cmd/testdata/repo/go.sum b/cmd/testdata/repo/go.sum
+index 66b216a..abebfc8 100644
 --- a/cmd/testdata/repo/go.sum
 +++ b/cmd/testdata/repo/go.sum
-@@ -2,5 +2,5 @@ golang.org/x/mod v0.13.0 h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=
+@@ -4,5 +4,5 @@ golang.org/x/mod v0.13.0 h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=
  golang.org/x/mod v0.13.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
  golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
  golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
That is, mark a module as modified if it's part of a `replace` directive that has been modified in some way