### PR TITLE
Pin SHAs to actions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5
         with:
           go-version: ${{ matrix.go_version }}
       - name: test
@@ -33,9 +33,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-    - uses: actions/setup-go@v5
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+    - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5
+    - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5
       with:
         go-version-file: 'go.mod'
-    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5
         with:
           go-version-file: 'go.mod'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@026299872805cb2db698e02dd7fb506a4da5122d  # v6.2.0
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
Mostly a response to CVE-2025-30066: avoid using tags that someone nefarious could replace vs. complete SHAs. I intentionally downgraded some actions to see how `dependabot` handles updating them.