### PR TITLE
Update test action Go versioning

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         go_version:
-          - "1.22"
-          - "1.23"
+          - "stable"
+          - "oldstable"
         os:
           - windows-latest
           - ubuntu-latest


### PR DESCRIPTION
So it automatically runs using the latest two Go versions (i.e. the currently support versions, per the release schedule) using some magical versions in the `setup-go` action.

This job was actually just testing Go 1.23 twice since d3fa37d3364f993080b76d1a4a93bc63cfe77c4f because of how that bumped the `go` directive in `go.mod`