### PR TITLE
Move to `golangci-lint` v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,34 +1,11 @@
+version: "2"
 run:
   tests: true
-
-linters-settings:
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
-  revive:
-    rules:
-      - name: exported
-        disabled: true
-      - name: context-as-argument
-        disabled: false
-  nolintlint:
-    require-specific: true
-  errorlint:
-    errorf: false
-  gci:
-    sections:
-      - standard
-      - default
-      - localmodule
 linters:
-  enable-all: true
-
+  default: all
   disable:
-    # deprecated linters
-    - exportloopref
-
     # conflicting/cover same issues
-    - forcetypeassert # covered by errcheck
+    - forcetypeassert # coverd by errcheck
 
     # personal preference
     - gocritic
@@ -45,3 +22,47 @@ linters:
     # premature optimisation that creates inconsistent code (sometimes Sprintf, sometimes string concatenation)
     # consider enabling _if_ you've profile performance _and_ Sprintf calls are slowing you down
     - perfsprint
+  settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    errorlint:
+      errorf: false
+    nolintlint:
+      require-specific: true
+    revive:
+      rules:
+        - name: exported
+          disabled: true
+        - name: context-as-argument
+          disabled: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+    - golines
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: format-markdown-docker
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v1.62.0
+    rev: v2.1.2
     hooks:
     -   id: golangci-lint-full
         language_version: "1.23.0"
@@ -12,11 +12,6 @@ repos:
     rev: v0.2.0
     hooks:
     -   id: validate-changelog
--   repo: https://github.com/matthewhughes934/golines
-    rev: v0.12.0
-    hooks:
-    -   id: golines
-        exclude: testdata
 -   repo: https://gitlab.com/matthewhughes/go-pre-commit
     rev: v0.3.0
     hooks:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	gitlab.com/matthewhughes/go-cov v0.5.0
 	gitlab.com/matthewhughes/signalctx v0.1.0
 	gitlab.com/matthewhughes/slogctx v0.2.0
-	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f
 	golang.org/x/mod v0.23.0
 	golang.org/x/tools v0.30.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ gitlab.com/matthewhughes/signalctx v0.1.0 h1:Mo11/Nh2nfyWZaRz3YI0a6iqI1Z2KOAviae
 gitlab.com/matthewhughes/signalctx v0.1.0/go.mod h1:EaDNvEC/XQoNwgf3STyu6qL9WZ+OtDN7+jj+zrASZ3I=
 gitlab.com/matthewhughes/slogctx v0.2.0 h1:JOvSSp15IW08HIVV3gFCzwLn4hii0hXxD0RCfKP52p4=
 gitlab.com/matthewhughes/slogctx v0.2.0/go.mod h1:GagyMC87srtYHICSdR+DUgQJslxr8fc8CmgpG2jSgiw=
-golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f h1:XdNn9LlyWAhLVp6P/i8QYBW+hlyhrhei9uErw2B5GJo=
-golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f/go.mod h1:D5SMRVC3C2/4+F/DB1wZsLRnSNimn2Sp/NPsCrsv8ak=
 golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
 golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=

--- a/pkg/changed/changed.go
+++ b/pkg/changed/changed.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"path/filepath"
 	"slices"
 	"strings"
 
 	"gitlab.com/matthewhughes/slogctx"
-	"golang.org/x/exp/maps"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
 	"golang.org/x/tools/go/packages"
@@ -78,7 +78,10 @@ func GetChangedPackages(
 		}
 	}
 
-	return maps.Keys(changedPackages), nil
+	return slices.AppendSeq(
+		make([]string, 0, len(changedPackages)),
+		maps.Keys(changedPackages),
+	), nil
 }
 
 func loadLocalPackages(ctx context.Context, modDir string) ([]*packages.Package, error) {


### PR DESCRIPTION
Migrate the config with:

    golangci-lint migrate

Then re-add some comments. v2 also brings in `golines` as a formatter, so enable that and drop the `pre-commit` hook for it.